### PR TITLE
add the possibility to specify a namespace for the ros2 topics/services of the legacy gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Qt install dir. On my system, this value is `/opt/qt512/5.12.3/gcc_64`.
 ### running
  - `XBotCore -D` (or gazebo equivalent)
  - `rosrun robot_monitoring joint_state_gui`
+
+ You can launch the legacy GUI with a different namespace using the following
+ 
+ ```
+ xbot2-gui --ros_args --rmap __ns:=/mynamespace
+ ```

--- a/src/joint_sliders/sliders_widget_mainview.cpp
+++ b/src/joint_sliders/sliders_widget_mainview.cpp
@@ -37,8 +37,8 @@ cartesio_gui::SlidersWidgetMainView::Options::Options():
     message_type("xbot_msgs"),
     enable_velocity_tab(true),
     enable_effort_tab(true),
-    joint_state_topic("/xbotcore/joint_states"),
-    command_topic("/xbotcore/command")
+    joint_state_topic("xbotcore/joint_states"),
+    command_topic("xbotcore/command")
 {
 }
 
@@ -641,5 +641,4 @@ void cartesio_gui::SlidersWidgetMainView::set_ros_namespace()
         make_publisher();
     }
 }
-
 

--- a/src/joint_state_gui/joint_monitor_widget.cpp
+++ b/src/joint_state_gui/joint_monitor_widget.cpp
@@ -30,7 +30,7 @@ JointMonitorWidget::JointMonitorWidget(int argc,
     create_menu();
 
     _jstate_sub = _node->create_subscription<xbot_msgs::msg::JointState>(
-        "/xbotcore/joint_states",
+        "xbotcore/joint_states",
         rclcpp::SensorDataQoS().keep_last(10),
         std::bind(&JointMonitorWidget::on_jstate_recv, this, _1)
     );
@@ -92,19 +92,19 @@ JointMonitorWidget::JointMonitorWidget(int argc,
 
     // subscribers to fault and aux
     _fault_sub = _node->create_subscription<xbot_msgs::msg::Fault>(
-        "/xbotcore/fault",
+        "xbotcore/fault",
         10,
         std::bind(&JointMonitorWidget::on_fault_recv, this, _1));
 
     _aux_sub = _node->create_subscription<xbot_msgs::msg::CustomState>(
-        "/xbotcore/aux",
+        "xbotcore/aux",
         10,
         std::bind(&JointMonitorWidget::on_aux_recv, this, _1));
 
     // get robot description with topic in ros2
     std::string urdf_string;
     auto urdf_sub = _node->create_subscription<std_msgs::msg::String>(
-        "/xbotcore/robot_description",
+        "xbotcore/robot_description",
         rclcpp::ParametersQoS().transient_local(),
         [&urdf_string](std_msgs::msg::String::ConstSharedPtr msg) {
             urdf_string = msg->data;
@@ -112,7 +112,7 @@ JointMonitorWidget::JointMonitorWidget(int argc,
     );
 
     while(urdf_string.empty()) {
-        RCLCPP_INFO(_node->get_logger(), "Waiting /xbotcore/robot_description");
+        RCLCPP_INFO(_node->get_logger(), "Waiting for xbotcore/robot_description");
         rclcpp::spin_some(_node);        
         usleep(10000);
     }

--- a/src/joint_state_gui/xbot2_status_wid.cpp
+++ b/src/joint_state_gui/xbot2_status_wid.cpp
@@ -77,7 +77,7 @@ XBot2StatusWidget::XBot2StatusWidget(QMainWindow * mw,
 
     _last_status_recv = _node->get_clock()->now(); //initialization
     auto status_sub = _node->create_subscription<std_msgs::msg::String>(
-        "/xbotcore/status", 
+        "xbotcore/status", 
         rclcpp::SensorDataQoS().keep_last(1), 
         [this](const std_msgs::msg::String msg) -> void
         {
@@ -239,7 +239,7 @@ XBot2StatusWidget::XBot2StatusWidget(QMainWindow * mw,
         }
     };
 
-    _vbatt_sub = _node->create_subscription<std_msgs::msg::Float32>("/xbotcore/vbatt", 1, on_vbatt_recv);
+    _vbatt_sub = _node->create_subscription<std_msgs::msg::Float32>("xbotcore/vbatt", 1, on_vbatt_recv);
 
     _lcd = findChild<QLCDNumber*>("voltLcd");
     _lcd->setStyleSheet("border: 0px");
@@ -268,7 +268,7 @@ XBot2StatusWidget::XBot2StatusWidget(QMainWindow * mw,
     auto shutdownBtnClicked = [this]()
     {
         rclcpp::Client<xbot_msgs::srv::StopProcess>::SharedPtr cli_stop =
-            _node->create_client<xbot_msgs::srv::StopProcess>("/xbotcore/d/stop");
+            _node->create_client<xbot_msgs::srv::StopProcess>("xbotcore/d/stop");
 
         auto request_stop = std::make_shared<xbot_msgs::srv::StopProcess::Request>();
         request_stop->signum = 0;
@@ -278,7 +278,7 @@ XBot2StatusWidget::XBot2StatusWidget(QMainWindow * mw,
                 RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Interrupted while waiting for the service. Exiting.");
                 return 0;
             }
-            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "service /xbotcore/d/stop not available, waiting again...");
+            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "service xbotcore/d/stop not available, waiting again...");
         }
 
         auto result_stop = cli_stop->async_send_request(request_stop);

--- a/src/joint_state_gui/xbot2_wid.cpp
+++ b/src/joint_state_gui/xbot2_wid.cpp
@@ -192,7 +192,7 @@ XBot2Widget::XBot2Widget(QMainWindow * mw, QWidget * parent, rclcpp::Node::Share
     auto disableEnableBtn = findChild<QPushButton*>("disableEnableBtn");
 
     auto setmask_srv = _node->create_client<xbot_msgs::srv::SetControlMask>(
-        "/joint_master/set_control_mask");
+        "joint_master/set_control_mask");
     //setmask_srv.waitForExistence();
 
     connect(disableEnableBtn, &QPushButton::released,
@@ -250,7 +250,7 @@ XBot2Widget::XBot2Widget(QMainWindow * mw, QWidget * parent, rclcpp::Node::Share
 
     /* Add plugins */
     auto pluginsLayout = findChild<QVBoxLayout *>("pluginsLayout");
-    auto client = _node->create_client<xbot_msgs::srv::GetPluginList>("/xbotcore/get_plugin_list");
+    auto client = _node->create_client<xbot_msgs::srv::GetPluginList>("xbotcore/get_plugin_list");
     auto request = std::make_shared<xbot_msgs::srv::GetPluginList::Request>();
 
     auto srv_data = client->async_send_request(request);
@@ -259,7 +259,7 @@ XBot2Widget::XBot2Widget(QMainWindow * mw, QWidget * parent, rclcpp::Node::Share
           RCLCPP_ERROR(_node->get_logger(), "Interrupted while waiting for the service. Exiting.");
           throw std::runtime_error("Service interrupted while waiting for get_plugin_list");
         }
-        RCLCPP_INFO(_node->get_logger(), "service /xbotcore/get_plugin_list not available, waiting again...");
+        RCLCPP_INFO(_node->get_logger(), "service xbotcore/get_plugin_list not available, waiting again...");
       }
 
     // Wait for the result.
@@ -284,7 +284,7 @@ XBot2Widget::XBot2Widget(QMainWindow * mw, QWidget * parent, rclcpp::Node::Share
 
         // connect buttons
         auto switch_srv = _node->create_client<std_srvs::srv::SetBool>(
-            "/xbotcore/" + plname + "/switch");
+            "xbotcore/" + plname + "/switch");
 
         switch_srvs.push_back(switch_srv);
 
@@ -311,7 +311,7 @@ XBot2Widget::XBot2Widget(QMainWindow * mw, QWidget * parent, rclcpp::Node::Share
         );
 
         auto abort_srv = _node->create_client<std_srvs::srv::Trigger>(
-             "/xbotcore/" + plname + "/abort");
+             "xbotcore/" + plname + "/abort");
 
         abort_srvs.push_back(abort_srv);
 
@@ -379,7 +379,7 @@ XBot2Widget::XBot2Widget(QMainWindow * mw, QWidget * parent, rclcpp::Node::Share
     auto on_stats_recv = 
 
     _stats_sub = _node->create_subscription<xbot_msgs::msg::Statistics2>(
-        "/xbotcore/statistics",
+        "xbotcore/statistics",
         1,
         [this](const xbot_msgs::msg::Statistics2::SharedPtr msg)
         {
@@ -427,7 +427,7 @@ XBot2Widget::XBot2Widget(QMainWindow * mw, QWidget * parent, rclcpp::Node::Share
 
 
     _jdinfo_sub = _node->create_subscription<xbot_msgs::msg::JointDeviceInfo>(
-        "/xbotcore/joint_device_info",
+        "xbotcore/joint_device_info",
         1,
         [enableFilterCheck, disableEnableBtn, safeBtn, mediumBtn, fastBtn] (const xbot_msgs::msg::JointDeviceInfo::SharedPtr msg)
         {

--- a/src/rviz/rviz_widget.cpp
+++ b/src/rviz/rviz_widget.cpp
@@ -33,7 +33,7 @@ RvizWidget::RvizWidget(QWidget* parent)
                                            true);
 
     _robot_model->subProp("Robot Description")->
-        setValue("/xbotcore/robot_description");
+        setValue("xbotcore/robot_description");
 
     Ogre::ColourValue colour(1, 1, 1, 0.9);
     _render_panel->setBackgroundColor(colour);


### PR DESCRIPTION
Basically removing the / : tested in simulation with the doosan robot with or without namespace.